### PR TITLE
Add behavior modifiers

### DIFF
--- a/src/executor/engine/core.rs
+++ b/src/executor/engine/core.rs
@@ -99,6 +99,7 @@ pub struct Engine {
     flags: u64,
     capabilities: u64,
     block_version: u32,
+    global_id: i32,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -250,11 +251,16 @@ impl Engine {
             flags: 0,
             capabilities,
             block_version: 0,
+            global_id: 0,
         }
     }
 
     pub fn set_block_version(&mut self, block_version: u32) {
         self.block_version = block_version
+    }
+
+    pub fn set_global_id(&mut self, global_id: i32) {
+        self.global_id = global_id;
     }
 
     pub fn assert_ctrl(&self, ctrl: usize, item: &StackItem) -> &Engine {
@@ -284,6 +290,10 @@ impl Engine {
 
     pub fn block_version(&self) -> u32 {
         self.block_version
+    }
+
+    pub fn global_id(&self) -> i32 {
+        self.global_id
     }
 
     pub fn check_or_set_flags(&mut self, flags: u64) -> bool {


### PR DESCRIPTION
Some SDK users want to calculate the commission without a signature. This PR adds `chksig_always_succeed` which is used to skip signature verification.